### PR TITLE
Add elemental support

### DIFF
--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -181,52 +181,6 @@ spec:
         kind: DigitaloceanConfig
         {{- else if eq $.Values.cloudprovider "azure" }}
         kind: AzureConfig
-        {{- end}}
-        name: {{ $nodepool.name }}
-      displayName: {{ $nodepool.displayName | default $nodepool.name }}
-      {{- if $nodepool.drainBeforeDelete }}
-      drainBeforeDelete: {{ $nodepool.drainBeforeDelete }}
-      {{- end }}
-      {{- if $nodepool.drainBeforeDeleteTimeout }}
-      drainBeforeDeleteTimeout: {{ $nodepool.drainBeforeDeleteTimeout }}
-      {{- end }}
-      {{- if $nodepool.machineDeploymentLabels }}
-      machineDeploymentLabels:
-      {{ toYaml $nodepool.machineDeploymentLabels | indent 8 }}
-      {{- end }}
-      {{- if $nodepool.machineDeploymentAnnotations }}
-      machineDeploymentAnnotations:
-      {{ toYaml $nodepool.machineDeploymentAnnotations | indent 8 }}
-      {{- end }}
-      paused: {{ $nodepool.paused }}
-      {{- if $nodepool.rollingUpdate }}
-      rollingUpdate:
-        maxUnavailable: {{ $nodepool.rollingUpdate.maxUnavailable }}
-        maxSurge: {{ $nodepool.rollingUpdate.maxSurge }}
-      {{- end }}
-      {{- if $nodepool.unhealthyNodeTimeout }}
-      unhealthyNodeTimeout: {{ $nodepool.unhealthyNodeTimeout }}
-      {{- end }}
-      {{- end }}
-    {{- end }}
-    {{- if .Values.nodepool }}
-    {{ $nodepool := .Values.nodepool }}
-    - name: {{ $nodepool.name }}
-      quantity: {{ $nodepool.quantity }}
-      controlPlaneRole: {{ $nodepool.controlplane }}
-      etcdRole: {{ $nodepool.etcd }}
-      workerRole: {{ $nodepool.worker }}
-      machineConfigRef:
-        {{- if eq $.Values.cloudprovider "amazonec2" }}
-        kind: Amazonec2Config
-        {{- else if eq $.Values.cloudprovider "vsphere" }}
-        kind: VmwarevsphereConfig
-        {{- else if eq $.Values.cloudprovider "harvester" }}
-        kind: HarvesterConfig
-        {{- else if eq $.Values.cloudprovider "digitalocean" }}
-        kind: DigitaloceanConfig
-        {{- else if eq $.Values.cloudprovider "azure" }}
-        kind: AzureConfig
         {{- else if eq $.Values.cloudprovider "elemental" }}
         apiVersion: elemental.cattle.io/v1beta1
         kind: MachineInventorySelectorTemplate 
@@ -255,6 +209,7 @@ spec:
       {{- end }}
       {{- if $nodepool.unhealthyNodeTimeout }}
       unhealthyNodeTimeout: {{ $nodepool.unhealthyNodeTimeout }}
+      {{- end }}
       {{- end }}
     {{- end }}
     {{- if or .Values.cluster.config.controlPlaneConfig .Values.cluster.config.workerConfig}}

--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -227,6 +227,9 @@ spec:
         kind: DigitaloceanConfig
         {{- else if eq $.Values.cloudprovider "azure" }}
         kind: AzureConfig
+        {{- else if eq $.Values.cloudprovider "elemental" }}
+        apiVersion: elemental.cattle.io/v1beta1
+        kind: MachineInventorySelectorTemplate 
         {{- end}}
         name: {{ $nodepool.name }}
       displayName: {{ $nodepool.displayName | default $nodepool.name }}

--- a/charts/cluster-templates/templates/nodeconfig-elemental.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-elemental.yaml
@@ -1,6 +1,5 @@
 {{- if eq .Values.cloudprovider "elemental" }}
 {{- range $index, $nodepool := .Values.nodepools }}
----
 apiVersion: elemental.cattle.io/v1beta1
 kind: MachineInventorySelectorTemplate
 metadata:
@@ -12,4 +11,4 @@ spec:
       selector:
         {{- toYaml $nodepool.selector | nindent 8 }}
 {{- end }}
-{{- end }}   
+{{- end }}

--- a/charts/cluster-templates/templates/nodeconfig-elemental.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-elemental.yaml
@@ -1,0 +1,15 @@
+{{- if eq .Values.cloudprovider "elemental" }}
+{{- range $index, $nodepool := .Values.nodepools }}
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: {{ $nodepool.name }}
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        {{- toYaml $nodepool.selector | nindent 8 }}
+{{- end }}
+{{- end }}   

--- a/charts/cluster-templates/values-elemental.yaml
+++ b/charts/cluster-templates/values-elemental.yaml
@@ -1,0 +1,161 @@
+# be sure to add all "required" values...
+
+# amazonec2, azure, digitalocean, harvester, vsphere, custom
+cloudprovider: elemental
+
+# cloud provider credentials (example: aws-creds)
+cloudCredentialSecretName:
+
+# rancher manager url
+rancher:
+  cattle:
+    url: # required (example: rancher.example.com)
+
+# cluster values
+cluster:
+  # annotations:
+    # key: value
+  # labels:
+    # key: value
+  name: elemental-cluster
+  config:
+    systemDefaultRegistry: docker.io # default registry
+    kubernetesVersion: v1.27.12+rke2r1 # https://github.com/rancher/rke2/releases
+    localClusterAuthEndpoint:
+      enabled: false
+    # agentEnvVars:
+      # - key:value
+    cni: canal # canal, calico, cilium, multus,canal, multus,calico, multus,cilium
+    docker: false
+    disable_kube_proxy: false
+    etcd_expose_metrics: false
+    enableNetworkPolicy: true
+    # defaultClusterRoleForProjectMembers: ''
+    # defaultPodSecurityAdmissionConfigurationTemplateName: ''
+    # defaultPodSecurityPolicyTemplateName: ''
+    profile: '' # cis-1.6, cis-1.23
+    selinux: false
+    secrets_encryption: false
+    write_kubeconfig_mode: 0600
+    use_service_account_credentials: false
+    protect_kernel_defaults: false
+    cloud_provider_name: '' # https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers
+    # cloud_provider_config: '' # cloud provider config secret here (example: secret://fleet-default:cloudprovider)
+    # kube_controller_manager_arg:
+      # - kube controller manager arguments here (https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager)
+    # kube_scheduler_arg:
+      # - kube scheduler arguments here (https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler)
+    # kube_apiserver_arg:
+      # - kube apiserver arguments here (https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver)
+    # kubelet_arg:
+      # - kubelet arguments here (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet)
+    registries:
+      enabled: false
+      # configs:
+        # - name: registry.example.com
+          # authConfigSecretName: registry-creds
+          # caBundle: ''
+          # insecureSkipVerify: false
+          # tlsSecretName: ''
+      # mirrors:
+        # - name: docker.io
+          # endpoints: ['registry.example.com']
+      # rewrite:
+         # "^rancher/(.*)": "mirrorproject/rancher-images/$1"
+    upgradeStrategy:
+      controlPlaneConcurrency: 10%
+      controlPlaneDrainOptions:
+        enabled: false
+        # deleteEmptyDirData: true
+        # disableEviction: false
+        # force: false
+        # gracePeriod: -1
+        # ignoreDaemonSets: true
+        # ignoreErrors: false
+        # skipWaitForDeleteTimeoutSeconds: 0
+        # timeout: 120
+      workerConcurrency: 10%
+      workerDrainOptions:
+        enabled: false
+        # deleteEmptyDirData: true
+        # disableEviction: false
+        # force: false
+        # gracePeriod: -1
+        # ignoreDaemonSets: true
+        # ignoreErrors: false
+        # skipWaitForDeleteTimeoutSeconds: 0
+        # timeout: 120
+
+# node and nodepool(s) values
+nodepools:
+  - name: control-plane
+    # displayName: cp-nodes
+    quantity: 3
+    etcd: true
+    controlplane: true
+    worker: false
+    # labels:
+      # key: value
+    # taints:
+      # effect: value
+      # key: value
+      # value: value
+    paused: false
+    # drainBeforeDelete: true
+    # drainBeforeDeleteTimeout: 30s
+    # unhealthyNodeTimeout: 60s
+    # machineDeploymentLabels:
+      # key: value
+    # machineDeploymentAnnotations:
+      # key: value
+    # rollingUpdate:
+      # maxUnavailable: 1
+      # maxSurge: 1
+    # cloud provider values here
+    selector:
+
+  - name: worker
+    # displayName: wk-nodes
+    quantity: 3
+    etcd: false
+    controlplane: false
+    worker: true
+    # labels:
+      # key: value
+    # taints:
+      # effect: value
+      # key: value
+      # value: value
+    paused: false
+    # drainBeforeDelete: true
+    # drainBeforeDeleteTimeout: 30s
+    # unhealthyNodeTimeout: 60s
+    # machineDeploymentLabels:
+      # key: value
+    # machineDeploymentAnnotations:
+      # key: value
+    # rollingUpdate:
+      # maxUnavailable: 1
+      # maxSurge: 1
+    # cloud provider values here
+    selector:
+
+# addons values
+addons:
+  monitoring:
+    enabled: false
+    # version: 103.0.3+up45.31.1
+    # values:
+      # values here
+
+  longhorn:
+    enabled: false
+    # version: 103.2.1+up1.5.3
+    # values:
+      # values here
+
+  neuvector:
+    enabled: false
+    # version: 103.0.1+up2.7.1
+    # values:
+      # values here

--- a/charts/cluster-templates/values-elemental.yaml
+++ b/charts/cluster-templates/values-elemental.yaml
@@ -111,8 +111,8 @@ nodepools:
     # rollingUpdate:
       # maxUnavailable: 1
       # maxSurge: 1
-    # cloud provider values here
-    selector:
+    selector: # https://elemental.docs.rancher.com/machineinventoryselectortemplate-reference
+      # key: value
 
   - name: worker
     # displayName: wk-nodes
@@ -137,8 +137,8 @@ nodepools:
     # rollingUpdate:
       # maxUnavailable: 1
       # maxSurge: 1
-    # cloud provider values here
-    selector:
+    selector: # https://elemental.docs.rancher.com/machineinventoryselectortemplate-reference
+      # key: value
 
 # addons values
 addons:


### PR DESCRIPTION
This PR adds the ability to deploy elemental clusters. The main changes are adding a machine config for elemental, and adding a MachineInventorySelectorTemplate resource that selects which machines in the Elemental Operator inventory to be used in a nodepool. 

When elemental clusters are created, machines automatically get added based on the selection criteria described above. When creating clusters all you have to do is specify helm values `cloudprovider=elemental` and define a nodepool with a valid node selector.