### PR TITLE
Tiny bug fixes

### DIFF
--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -287,7 +287,7 @@ spec:
         {{- end }}
       machineLabelSelector:
         matchLabels:
-          node-role.kubernetes.io/control-plane: true
+          node-role.kubernetes.io/control-plane: "true"
     {{- end }}
     {{- if .Values.cluster.config.workerConfig }}
     - config:
@@ -362,7 +362,7 @@ spec:
         {{- end }}
       machineLabelSelector:
         matchLabels:
-          rke.cattle.io/worker-role: true
+          rke.cattle.io/worker-role: "true"
       {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -381,7 +381,7 @@ spec:
       {{- if .Values.cluster.config.registries.mirrors }}
       mirrors:
         {{- range .Values.cluster.config.registries.mirrors }}
-        {{ .name }}:
+        {{ .name | quote }}:
           endpoint:
             {{- range .endpoints }}
             - {{ . }}


### PR DESCRIPTION
This PR has a fix for a YAML type inference bug in the cluster manifest. YAML automatically converts `true` to a boolean and not string, which does not meet the Cluster spec (string). The PR also adds support for specifying `"*"` in `registries.yaml` 