### PR TITLE
Remove chartValues definitions for Harvester && vSphere in cluster.yaml

### DIFF
--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -50,44 +50,7 @@ spec:
     additionalManifest:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- if eq $.Values.cloudprovider "harvester" }}
-    chartValues:
-      harvester-cloud-provider:
-        cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
-        global:
-          cattle:
-            clusterName: {{ .Values.cluster.name }}
-    {{- end }}
-    {{- if eq $.Values.cloudprovider "vsphere" }}
-    chartValues:
-      rke2-calico: {}
-      rancher-vsphere-cpi:
-        vCenter:
-          host: {{ .Values.vcenter.host }}
-          username: {{ .Values.vcenter.username }}
-          password: {{ .Values.vcenter.password }}
-          labels:
-            generate: false
-          datacenters: {{ .Values.vcenter.datacenters }}
-      rancher-vsphere-csi:
-        asyncQueryVolume:
-          enabled: {{ .Values.vcenter.vsphere.asyncQueryVolume.enabled | default true }}}
-        csiController:
-          csiResizer:
-            enabled: {{ .Values.vcenter.vsphere.csiController.csiResizer.enabled | default true }}
-        improvedVolumeTopology:
-          enabled: {{ .Values.vcenter.vsphere.improvedVolumeTopology.enabled | default true }}
-        onlineVolumeExtend:
-          enabled: {{ .Values.vcenter.vsphere.onlineVolumeExtend.enabled | default true }}
-        triggerCsiFullsync:
-          enabled: {{ .Values.vcenter.vsphere.triggerCsiFullsync.enabled | default true }}
-        vCenter:
-          datacenters: {{ .Values.vcenter.datacenters }}
-          host: {{ .Values.vcenter.host }}
-          username: {{ .Values.vcenter.username }}
-          password: {{ .Values.vcenter.password }}
-          insecureFlag: {{ .Values.vcenter.skip_tls_verify | default false }}
-    {{- end }}
+    chartValues: {}
     # etcd:
     # etcdSnapshotCreate:
     # etcdSnapshotRestore:

--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -46,11 +46,14 @@ spec:
   {{- end }}
   # redeploySystemAgentGeneration:
   rkeConfig:
+    {{- with $.Values.cluster.config.chartValues }}
+    chartValues:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- with $.Values.cluster.config.additionalManifests }}
     additionalManifest:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    chartValues: {}
     # etcd:
     # etcdSnapshotCreate:
     # etcdSnapshotRestore:

--- a/charts/cluster-templates/values.yaml
+++ b/charts/cluster-templates/values.yaml
@@ -23,6 +23,12 @@ cluster:
     enableNetworkPolicy: true
     localClusterAuthEndpoint:
       enabled: false
+    # chartValues: |-
+    #   harvester-cloud-provider:
+    #     cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
+    #     global:
+    #       cattle:
+    #         clusterName: {{ .Values.cluster.name }}
     # additionalManifests: |-
     #   apiVersion: v1
     #   kind: Pod


### PR DESCRIPTION
This change removes the chartValues definitions for Harvester and vSphere as they are no longer needed. You can still pass chartValues in its entirety in your values.yaml