### PR TITLE
feat: conforms machine refs to match the $clustername-$nodepool scheme

### DIFF
--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -1,3 +1,5 @@
+{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
+{{- $clustername := .Values.cluster.name -}}
 apiVersion: provisioning.cattle.io/v1
 kind: Cluster
 metadata:
@@ -154,7 +156,7 @@ spec:
         apiVersion: elemental.cattle.io/v1beta1
         kind: MachineInventorySelectorTemplate 
         {{- end}}
-        name: {{ $nodepool.name }}
+        name: {{ $clustername }}-{{ $nodepool.name }}
       displayName: {{ $nodepool.displayName | default $nodepool.name }}
       {{- if $nodepool.drainBeforeDelete }}
       drainBeforeDelete: {{ $nodepool.drainBeforeDelete }}

--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -1,4 +1,3 @@
-{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
 {{- $clustername := .Values.cluster.name -}}
 apiVersion: provisioning.cattle.io/v1
 kind: Cluster
@@ -154,7 +153,7 @@ spec:
         kind: AzureConfig
         {{- else if eq $.Values.cloudprovider "elemental" }}
         apiVersion: elemental.cattle.io/v1beta1
-        kind: MachineInventorySelectorTemplate 
+        kind: MachineInventorySelectorTemplate
         {{- end}}
         name: {{ $clustername }}-{{ $nodepool.name }}
       displayName: {{ $nodepool.displayName | default $nodepool.name }}

--- a/charts/cluster-templates/templates/nodeconfig-aws.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-aws.yaml
@@ -1,9 +1,11 @@
+{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
+{{- $clustername := .Values.cluster.name -}}
 {{- if eq .Values.cloudprovider "amazonec2" }}
 {{- range $index, $nodepool := .Values.nodepools }}
 apiVersion: rke-machine-config.cattle.io/v1
 kind: Amazonec2Config
 metadata:
-  name: {{ $nodepool.name }}
+  name: {{ $clustername }}-{{ $nodepool.name }}
   namespace: fleet-default
 {{- if $nodepool.accessKey }}
 accessKey: {{ $nodepool.accessKey }}
@@ -123,7 +125,7 @@ zone: {{ $nodepool.zone }}
 apiVersion: rke-machine-config.cattle.io/v1
 kind: Amazonec2Config
 metadata:
-  name: {{ $nodepool.name }}
+  name: {{ $clustername }}-{{ $nodepool.name }}
   namespace: fleet-default
 common:
 {{- if $nodepool.labels }}

--- a/charts/cluster-templates/templates/nodeconfig-aws.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-aws.yaml
@@ -1,4 +1,3 @@
-{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
 {{- $clustername := .Values.cluster.name -}}
 {{- if eq .Values.cloudprovider "amazonec2" }}
 {{- range $index, $nodepool := .Values.nodepools }}

--- a/charts/cluster-templates/templates/nodeconfig-azure.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-azure.yaml
@@ -1,4 +1,3 @@
-{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
 {{- $clustername := .Values.cluster.name -}}
 {{- if eq .Values.cloudprovider "azure" }}
 {{- range $index, $nodepool := .Values.nodepools }}

--- a/charts/cluster-templates/templates/nodeconfig-azure.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-azure.yaml
@@ -1,9 +1,11 @@
+{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
+{{- $clustername := .Values.cluster.name -}}
 {{- if eq .Values.cloudprovider "azure" }}
 {{- range $index, $nodepool := .Values.nodepools }}
 apiVersion: rke-machine-config.cattle.io/v1
 kind: AzureConfig
 metadata:
-  name: {{ $nodepool.name }}
+  name: {{ $clustername }}-{{ $nodepool.name }}
   namespace: fleet-default
 common:
 {{- if $nodepool.labels }}
@@ -50,7 +52,7 @@ vnet: {{ $nodepool.vnet }}
 apiVersion: rke-machine-config.cattle.io/v1
 kind: AzureConfig
 metadata:
-  name: {{ $nodepool.name }}
+  name: {{ $clustername }}-{{ $nodepool.name }}
   namespace: fleet-default
 common:
 {{- if $nodepool.labels }}

--- a/charts/cluster-templates/templates/nodeconfig-do.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-do.yaml
@@ -1,9 +1,11 @@
+{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
+{{- $clustername := .Values.cluster.name -}}
 {{- if eq .Values.cloudprovider "digitalocean" }}
 {{- range $index, $nodepool := .Values.nodepools }}
 apiVersion: rke-machine-config.cattle.io/v1
 kind: DigitaloceanConfig
 metadata:
-  name: {{ $nodepool.name }}
+  name: {{ $clustername }}-{{ $nodepool.name }}
   namespace: fleet-default
 {{- if $nodepool.accessToken }}
 accessToken: {{ $nodepool.accessToken }}
@@ -54,7 +56,7 @@ userdata: {{- $nodepool.userData | toYaml | indent 1 }}
 apiVersion: rke-machine-config.cattle.io/v1
 kind: DigitaloceanConfig
 metadata:
-  name: {{ $nodepool.name }}
+  name: {{ $clustername }}-{{ $nodepool.name }}
   namespace: fleet-default
 {{- if $nodepool.accessToken }}
 accessToken: {{ $nodepool.accessToken }}

--- a/charts/cluster-templates/templates/nodeconfig-do.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-do.yaml
@@ -1,4 +1,3 @@
-{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
 {{- $clustername := .Values.cluster.name -}}
 {{- if eq .Values.cloudprovider "digitalocean" }}
 {{- range $index, $nodepool := .Values.nodepools }}

--- a/charts/cluster-templates/templates/nodeconfig-elemental.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-elemental.yaml
@@ -1,9 +1,11 @@
+{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
+{{- $clustername := .Values.cluster.name -}}
 {{- if eq .Values.cloudprovider "elemental" }}
 {{- range $index, $nodepool := .Values.nodepools }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: MachineInventorySelectorTemplate
 metadata:
-  name: {{ $nodepool.name }}
+  name: {{ $clustername }}-{{ $nodepool.name }}
   namespace: fleet-default
 spec:
   template:

--- a/charts/cluster-templates/templates/nodeconfig-elemental.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-elemental.yaml
@@ -1,4 +1,3 @@
-{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
 {{- $clustername := .Values.cluster.name -}}
 {{- if eq .Values.cloudprovider "elemental" }}
 {{- range $index, $nodepool := .Values.nodepools }}

--- a/charts/cluster-templates/templates/nodeconfig-harvester.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-harvester.yaml
@@ -1,4 +1,3 @@
-{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
 {{- $clustername := .Values.cluster.name -}}
 {{- if eq .Values.cloudprovider "harvester" }}
 {{- range $index, $nodepool := .Values.nodepools }}

--- a/charts/cluster-templates/templates/nodeconfig-harvester.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-harvester.yaml
@@ -1,9 +1,11 @@
+{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
+{{- $clustername := .Values.cluster.name -}}
 {{- if eq .Values.cloudprovider "harvester" }}
 {{- range $index, $nodepool := .Values.nodepools }}
 apiVersion: rke-machine-config.cattle.io/v1
 kind: HarvesterConfig
 metadata:
-  name: {{ $nodepool.name }}
+  name: {{ $clustername }}-{{ $nodepool.name }}
   namespace: fleet-default
 {{- if $nodepool.cloudConfig }}
 cloudConfig: {{$nodepool.cloudconfig }}
@@ -81,7 +83,7 @@ vmNamespace: {{ $nodepool.vmNamespace }}
 apiVersion: rke-machine-config.cattle.io/v1
 kind: HarvesterConfig
 metadata:
-  name: {{ $nodepool.name }}
+  name: {{ $clustername }}-{{ $nodepool.name }}
   namespace: fleet-default
 common:
 {{- if $nodepool.labels }}

--- a/charts/cluster-templates/templates/nodeconfig-vsphere.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-vsphere.yaml
@@ -1,4 +1,3 @@
-{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
 {{- $clustername := .Values.cluster.name -}}
 {{- if eq .Values.cloudprovider "vsphere" }}
 {{- range $index, $nodepool := .Values.nodepools }}

--- a/charts/cluster-templates/templates/nodeconfig-vsphere.yaml
+++ b/charts/cluster-templates/templates/nodeconfig-vsphere.yaml
@@ -1,9 +1,11 @@
+{{- /* Defines clustername variable for use inside of range functions within this chart. */}}
+{{- $clustername := .Values.cluster.name -}}
 {{- if eq .Values.cloudprovider "vsphere" }}
 {{- range $index, $nodepool := .Values.nodepools }}
 apiVersion: rke-machine-config.cattle.io/v1
 kind: VmwarevsphereConfig
 metadata:
-  name: {{ $nodepool.name }}
+  name: {{ $clustername }}-{{ $nodepool.name }}
   namespace: fleet-default
 common:
 {{- if $nodepool.labels }}
@@ -51,7 +53,7 @@ vcenterPort: {{ $nodepool.vcenterPort | squote }}
 apiVersion: rke-machine-config.cattle.io/v1
 kind: VmwarevsphereConfig
 metadata:
-  name: {{ $nodepool.name }}
+  name: {{ $clustername }}-{{ $nodepool.name }}
   namespace: fleet-default
 common:
 {{- if $nodepool.labels }}


### PR DESCRIPTION
This should address the issue that rest of the objects created by rancher for a cluster are either unique and scoped to a cluster or are named with a cluster name prefix. So if you create a nodepool named "control-plane" on two different clusters it would have previously failed because the machineConfigRef would be duplicated. If the nodepool.name value is "cluster-1-control-plane" then it would create machine named "cluster-1-cluster-1-control-plane" which is not ideal.

That said this affects all nodepool configs templates because it gets referenced in the cluster.yaml, but I have only tested vsphere deployments. So I do not recommend merging until they have been actually tested. If that is too large of a burden I can refactor to have the machineConfigRef.name be provider specific to just tested providers.