### PR TITLE
fix agentEnvVars key:values indention

### DIFF
--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   {{- if .Values.cluster.config.agentEnvs }}
   agentEnvVars:
-  {{ toYaml .Values.cluster.config.agentEnvs | indent 4 }}
+{{ toYaml .Values.cluster.config.agentEnvs | indent 4 }}
   {{- end }}
   {{- if .Values.cloudCredentialSecretName }}
   cloudCredentialSecretName: cattle-global-data:{{ .Values.cloudCredentialSecretName }}

--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -12,9 +12,9 @@ metadata:
   name: {{ .Values.cluster.name }}
   namespace: fleet-default
 spec:
-  {{- if .Values.cluster.config.agentEnvs }}
+  {{- if .Values.cluster.config.agentEnvVars }}
   agentEnvVars:
-{{ toYaml .Values.cluster.config.agentEnvs | indent 4 }}
+{{ toYaml .Values.cluster.config.agentEnvVars | indent 4 }}
   {{- end }}
   {{- if .Values.cloudCredentialSecretName }}
   cloudCredentialSecretName: cattle-global-data:{{ .Values.cloudCredentialSecretName }}
@@ -152,7 +152,7 @@ spec:
         kind: AzureConfig
         {{- else if eq $.Values.cloudprovider "elemental" }}
         apiVersion: elemental.cattle.io/v1beta1
-        kind: MachineInventorySelectorTemplate 
+        kind: MachineInventorySelectorTemplate
         {{- end}}
         name: {{ $nodepool.name }}
       displayName: {{ $nodepool.displayName | default $nodepool.name }}

--- a/charts/cluster-templates/values-aws.yaml
+++ b/charts/cluster-templates/values-aws.yaml
@@ -35,7 +35,8 @@ cluster:
     #       ports:
     #       - containerPort: 80
     # agentEnvVars:
-      # - key:value
+      # - name: key
+      #   value: value
     # defaultClusterRoleForProjectMembers: ''
     # defaultPodSecurityAdmissionConfigurationTemplateName: ''
     # defaultPodSecurityPolicyTemplateName: ''

--- a/charts/cluster-templates/values-custom.yaml
+++ b/charts/cluster-templates/values-custom.yaml
@@ -32,7 +32,8 @@ cluster:
     #       ports:
     #       - containerPort: 80
     # agentEnvVars:
-      # - key:value
+      # - name: key
+      #   value: value
     # defaultClusterRoleForProjectMembers: ''
     # defaultPodSecurityAdmissionConfigurationTemplateName: ''
     # defaultPodSecurityPolicyTemplateName: ''

--- a/charts/cluster-templates/values-digitalocean.yaml
+++ b/charts/cluster-templates/values-digitalocean.yaml
@@ -35,7 +35,8 @@ cluster:
     #       ports:
     #       - containerPort: 80
     # agentEnvVars:
-      # - key:value
+      # - name: key
+      #   value: value
     # defaultClusterRoleForProjectMembers: ''
     # defaultPodSecurityAdmissionConfigurationTemplateName: ''
     # defaultPodSecurityPolicyTemplateName: ''

--- a/charts/cluster-templates/values-elemental.yaml
+++ b/charts/cluster-templates/values-elemental.yaml
@@ -35,7 +35,8 @@ cluster:
     #       ports:
     #       - containerPort: 80
     # agentEnvVars:
-      # - key:value
+      # - name: key
+      #   value: value
     # defaultClusterRoleForProjectMembers: ''
     # defaultPodSecurityAdmissionConfigurationTemplateName: ''
     # defaultPodSecurityPolicyTemplateName: ''

--- a/charts/cluster-templates/values-harvester.yaml
+++ b/charts/cluster-templates/values-harvester.yaml
@@ -35,7 +35,8 @@ cluster:
     #       ports:
     #       - containerPort: 80
     # agentEnvVars:
-      # - key:value
+      # - name: key
+      #   value: value
     # defaultClusterRoleForProjectMembers: ''
     # defaultPodSecurityAdmissionConfigurationTemplateName: ''
     # defaultPodSecurityPolicyTemplateName: ''

--- a/charts/cluster-templates/values.yaml
+++ b/charts/cluster-templates/values.yaml
@@ -41,7 +41,8 @@ cluster:
     #       ports:
     #       - containerPort: 80
     # agentEnvVars:
-      # - key:value
+      # - name: key
+      #   value: value
     # defaultClusterRoleForProjectMembers: ''
     # defaultPodSecurityAdmissionConfigurationTemplateName: ''
     # defaultPodSecurityPolicyTemplateName: ''


### PR DESCRIPTION
PR fixes issue when setting cluster.agentEnvs 

```yaml
cluster:
  config:
    agentEnvs:
      - name: "HTTP_PROXY"
        value: "http://proxy.example.com:3128"
```

Helm error:

> Error: YAML parse error on rancher-cluster-templates/templates/cluster.yaml: error converting YAML to JSON: yaml: line 8: did not find expected '-' indicator

