### PR TITLE
Set localClusterAuthEndpoint to Empty Hash if enabled is false.

### DIFF
--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -41,6 +41,8 @@ spec:
     enabled: {{ .Values.cluster.config.localClusterAuthEndpoint.enabled }}
     fqdn: {{ .Values.cluster.config.localClusterAuthEndpoint.fqdn }}
     caCerts: {{ .Values.cluster.config.localClusterAuthEndpoint.caCerts }}
+  {{- else }}
+  localClusterAuthEndpoint: {}
   {{- end }}
   # redeploySystemAgentGeneration:
   rkeConfig:

--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -41,9 +41,6 @@ spec:
     enabled: {{ .Values.cluster.config.localClusterAuthEndpoint.enabled }}
     fqdn: {{ .Values.cluster.config.localClusterAuthEndpoint.fqdn }}
     caCerts: {{ .Values.cluster.config.localClusterAuthEndpoint.caCerts }}
-  {{- else }}
-  localClusterAuthEndpoint:
-    enabled: false
   {{- end }}
   # redeploySystemAgentGeneration:
   rkeConfig:


### PR DESCRIPTION
Setting the enabled false value is not necessary here as the localClusterAuthEndpoint.enabled = false key is not required for it to be marked as disabled. Instead an empty hash value should be set.

From a manually deployed vSphere cluster's exported YAML which has this option disabled:
![image](https://github.com/user-attachments/assets/cffccae5-83cf-4e1f-914f-986a53696db9)
