### PR TITLE
fix(nodepools): apply labels and taints to nodepools

### DIFF
--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -166,6 +166,14 @@ spec:
       controlPlaneRole: {{ $nodepool.controlplane }}
       etcdRole: {{ $nodepool.etcd }}
       workerRole: {{ $nodepool.worker }}
+      {{- if $nodepool.labels }}
+      labels:
+{{ toYaml $nodepool.labels | indent 8 }}
+      {{- end }}
+      {{- if $nodepool.taints }}
+      taints:
+{{ toYaml $nodepool.taints | indent 8 }}
+      {{- end }}
       machineConfigRef:
         {{- if eq $.Values.cloudprovider "amazonec2" }}
         kind: Amazonec2Config


### PR DESCRIPTION
The cluster.yaml file previously did not add labels and taints to nodes after specifying in the labels and taints section under nodepools. This required adding labels and taints to the cluster.yaml template.