### PR TITLE
feat(registries): add fallback support for registry mirrors

### DIFF
--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -389,6 +389,9 @@ spec:
             {{- range .endpoints }}
             - {{ . }}
             {{- end }}
+          {{- if .fallback }}
+          fallback: {{ .fallback }}
+          {{- end }}
           {{- if .rewrite }}
           rewrite:
             {{- range $key, $value := .rewrite }}

--- a/charts/cluster-templates/values-aws.yaml
+++ b/charts/cluster-templates/values-aws.yaml
@@ -108,6 +108,7 @@ cluster:
       # mirrors:
         # - name: docker.io
           # endpoints: ['registry.example.com']
+          # fallback: true
       # rewrite:
          # "^rancher/(.*)": "mirrorproject/rancher-images/$1"
     upgradeStrategy:

--- a/charts/cluster-templates/values-custom.yaml
+++ b/charts/cluster-templates/values-custom.yaml
@@ -105,6 +105,7 @@ cluster:
       # mirrors:
         # - name: docker.io
           # endpoints: ['registry.example.com']
+          # fallback: true
       # rewrite:
          # "^rancher/(.*)": "mirrorproject/rancher-images/$1"
     upgradeStrategy:

--- a/charts/cluster-templates/values-digitalocean.yaml
+++ b/charts/cluster-templates/values-digitalocean.yaml
@@ -108,6 +108,7 @@ cluster:
       # mirrors:
         # - name: docker.io
           # endpoints: ['registry.example.com']
+          # fallback: true
       # rewrite:
          # "^rancher/(.*)": "mirrorproject/rancher-images/$1"
     upgradeStrategy:

--- a/charts/cluster-templates/values-elemental.yaml
+++ b/charts/cluster-templates/values-elemental.yaml
@@ -105,6 +105,7 @@ cluster:
       # mirrors:
         # - name: docker.io
           # endpoints: ['registry.example.com']
+          # fallback: true
       # rewrite:
          # "^rancher/(.*)": "mirrorproject/rancher-images/$1"
     upgradeStrategy:

--- a/charts/cluster-templates/values-harvester.yaml
+++ b/charts/cluster-templates/values-harvester.yaml
@@ -108,6 +108,7 @@ cluster:
       # mirrors:
         # - name: docker.io
           # endpoints: ['registry.example.com']
+          # fallback: true
       # rewrite:
          # "^rancher/(.*)": "mirrorproject/rancher-images/$1"
     upgradeStrategy:

--- a/charts/cluster-templates/values-vsphere.yaml
+++ b/charts/cluster-templates/values-vsphere.yaml
@@ -118,6 +118,7 @@ cluster:
       # mirrors:
         # - name: docker.io
           # endpoints: ['registry.example.com']
+          # fallback: true
       # rewrite:
          # "^rancher/(.*)": "mirrorproject/rancher-images/$1"
     upgradeStrategy:

--- a/charts/cluster-templates/values.yaml
+++ b/charts/cluster-templates/values.yaml
@@ -114,6 +114,7 @@ cluster:
       # mirrors:
         # - name: docker.io
           # endpoints: ['registry.example.com']
+          # fallback: true
       # rewrite:
          # "^rancher/(.*)": "mirrorproject/rancher-images/$1"
     upgradeStrategy:


### PR DESCRIPTION
Adds optional fallback field to registry mirror configuration, enabling automatic upstream registry fallback when mirror endpoints are unavailable. Prevents bootstrap deadlocks caused by circular dependencies between registry caches and storage providers.