### PR TITLE
Fix/add etcd s3 retention

### DIFF
--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -67,6 +67,7 @@ spec:
         folder: {{ .Values.cluster.config.etcd.s3.folder }}
         {{- end }}
         region: {{ .Values.cluster.config.etcd.s3.region }}
+        retention: {{ .Values.cluster.config.etcd.s3.retention }}
         skipSSLVerify: {{ .Values.cluster.config.etcd.s3.skipSSLVerify }}
         endpoint: {{ .Values.cluster.config.etcd.s3.endpoint }}
         {{- if .Values.cluster.config.etcd.s3.endpointCA }}

--- a/charts/cluster-templates/values-aws.yaml
+++ b/charts/cluster-templates/values-aws.yaml
@@ -50,6 +50,7 @@ cluster:
     #     cloudCredentialSecretName: minio-creds
     #     folder: rancher
     #     region: dummyregion
+    #     retention: 5
     #     skipSSLVerify: false
     #     endpoint: # minio.example.com
     #     endpointCA: |-

--- a/charts/cluster-templates/values-custom.yaml
+++ b/charts/cluster-templates/values-custom.yaml
@@ -47,6 +47,7 @@ cluster:
     #     cloudCredentialSecretName: minio-creds
     #     folder: rancher
     #     region: dummyregion
+    #     retention: 5
     #     skipSSLVerify: false
     #     endpoint: # minio.example.com
     #     endpointCA: |-

--- a/charts/cluster-templates/values-digitalocean.yaml
+++ b/charts/cluster-templates/values-digitalocean.yaml
@@ -50,6 +50,7 @@ cluster:
     #     cloudCredentialSecretName: minio-creds
     #     folder: rancher
     #     region: dummyregion
+    #     retention: 5
     #     skipSSLVerify: false
     #     endpoint: # minio.example.com
     #     endpointCA: |-

--- a/charts/cluster-templates/values-elemental.yaml
+++ b/charts/cluster-templates/values-elemental.yaml
@@ -47,6 +47,7 @@ cluster:
     #     cloudCredentialSecretName: minio-creds
     #     folder: rancher
     #     region: dummyregion
+    #     retention: 5
     #     skipSSLVerify: false
     #     endpoint: # minio.example.com
     #     endpointCA: |-

--- a/charts/cluster-templates/values-harvester.yaml
+++ b/charts/cluster-templates/values-harvester.yaml
@@ -50,6 +50,7 @@ cluster:
     #     cloudCredentialSecretName: minio-creds
     #     folder: rancher
     #     region: dummyregion
+    #     retention: 5
     #     skipSSLVerify: false
     #     endpoint: # minio.example.com
     #     endpointCA: |-

--- a/charts/cluster-templates/values-vsphere.yaml
+++ b/charts/cluster-templates/values-vsphere.yaml
@@ -60,6 +60,7 @@ cluster:
     #     cloudCredentialSecretName: minio-creds
     #     folder: rancher
     #     region: dummyregion
+    #     retention: 5
     #     skipSSLVerify: false
     #     endpoint: # minio.example.com
     #     endpointCA: |-

--- a/charts/cluster-templates/values.yaml
+++ b/charts/cluster-templates/values.yaml
@@ -56,6 +56,7 @@ cluster:
     #     cloudCredentialSecretName: minio-creds
     #     folder: rancher
     #     region: dummyregion
+    #     retention: 5
     #     skipSSLVerify: false
     #     endpoint: # minio.example.com
     #     endpointCA: |-


### PR DESCRIPTION
This PR adds the possibility to set a different retention for etcd snapshots stored in S3 than the snapshots stored local.
This contributes in general to issue #16 

The option to set a different retention for snapshots stored in S3 can be find upstream in this code:
https://github.com/rancher/rancher/blob/bcfacbd81af07c89117639b07fdb2076a56d58b9/pkg/apis/rke.cattle.io/v1/etcdsnapshot_types.go#L74
