### PR TITLE
Add audit-policy-file parameter

### DIFF
--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -81,6 +81,10 @@ spec:
     # infrastructureRef:
     {{- if .Values.cluster.config.globalConfig }}
     machineGlobalConfig:
+      {{- if .Values.cluster.config.controlPlaneConfig.audit_policy_file }}
+      audit-policy-file: |-
+{{ .Values.cluster.config.controlPlaneConfig.audit_policy_file | indent 8 }}
+      {{- end }}
       {{- if .Values.cluster.config.globalConfig.cni }}
       cni: {{ .Values.cluster.config.globalConfig.cni }}
       {{- end }}
@@ -220,6 +224,10 @@ spec:
     machineSelectorConfig:
     {{- if .Values.cluster.config.controlPlaneConfig }}
     - config:
+        {{- if .Values.cluster.config.controlPlaneConfig.audit_policy_file }}
+        audit-policy-file: |-
+{{ .Values.cluster.config.controlPlaneConfig.audit_policy_file | indent 10 }}
+        {{- end }}
         {{- if .Values.cluster.config.controlPlaneConfig.cni }}
         cni: {{ .Values.cluster.config.controlPlaneConfig.cni }}
         {{- end }}
@@ -295,6 +303,10 @@ spec:
     {{- end }}
     {{- if .Values.cluster.config.workerConfig }}
     - config:
+        {{- if .Values.cluster.config.controlPlaneConfig.audit_policy_file }}
+        audit-policy-file: |-
+{{ .Values.cluster.config.controlPlaneConfig.audit_policy_file | indent 10 }}
+        {{- end }}
         {{- if .Values.cluster.config.workerConfig.cni }}
         cni: {{ .Values.cluster.config.workerConfig.cni }}
         {{- end }}


### PR DESCRIPTION
The chart is currently missing the parameter to set an audit policy file according to the [documentation](https://ranchermanager.docs.rancher.com/v2.14/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters).

This PR adds the possibility to configure an audit policy via `globalConfig`, `controlPlaneConfig` or `workerConfig`.
It does not make sense to set this in `workerConfig` but because currently all parameters are still set across all sections I added it to all of them.