### PR TITLE
feat(cluster): add etcd_arg support to globalConfig and controlPlaneConfig

### DIFF
--- a/charts/cluster-templates/templates/cluster.yaml
+++ b/charts/cluster-templates/templates/cluster.yaml
@@ -108,6 +108,9 @@ spec:
       {{- if .Values.cluster.config.globalConfig.etcd_expose_metrics }}
       etcd-expose-metrics: {{ .Values.cluster.config.globalConfig.etcd_expose_metrics }}
       {{- end }}
+      {{- if .Values.cluster.config.globalConfig.etcd_arg }}
+      etcd-arg: {{ .Values.cluster.config.globalConfig.etcd_arg | toRawJson }}
+      {{- end }}
       {{- if .Values.cluster.config.globalConfig.profile }}
       profile: {{ .Values.cluster.config.globalConfig.profile }}
       {{- end }}
@@ -240,6 +243,9 @@ spec:
         {{- end }}
         {{- if .Values.cluster.config.controlPlaneConfig.etcd_expose_metrics }}
         etcd-expose-metrics: {{ .Values.cluster.config.controlPlaneConfig.etcd_expose_metrics }}
+        {{- end }}
+        {{- if .Values.cluster.config.controlPlaneConfig.etcd_arg }}
+        etcd-arg: {{ .Values.cluster.config.controlPlaneConfig.etcd_arg | toRawJson }}
         {{- end }}
         {{- if .Values.cluster.config.controlPlaneConfig.profile }}
         profile: {{ .Values.cluster.config.controlPlaneConfig.profile }}

--- a/charts/cluster-templates/values.yaml
+++ b/charts/cluster-templates/values.yaml
@@ -98,6 +98,9 @@ cluster:
         # - kube proxy arguments here (https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy)
       # kubelet_arg:
         # - kubelet arguments here (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet)
+      # etcd_arg:
+        # - etcd arguments here (https://etcd.io/docs/latest/op-guide/configuration/)
+        # - "quota-backend-bytes=5368709120" # increase keyspace to 5GB (default 2GB, max 8GB)
     # controlPlaneConfig:
       # same options as globalConfig
       # only will apply to the control plane nodes


### PR DESCRIPTION
## Summary

Adds support for passing arbitrary [etcd arguments](https://etcd.io/docs/latest/op-guide/configuration/)
to RKE2 via a new `etcd_arg` value, exposed in both `globalConfig` and `controlPlaneConfig`.

## Background (incident-driven)

This change is a preventative action following a production incident in which the embedded
etcd datastore reached its backend storage quota and entered a `NOSPACE` state, degrading the
Kubernetes control plane and causing the API server to reject writes. The trigger was an
Event storm — a high volume of Kubernetes `Event` objects generated by an admission policy
repeatedly evaluating short-lived, high-churn CI workloads — which grew the etcd database
past its **default 2 GB quota**.

Service was restored by compacting and defragmenting etcd, disarming the alarm, and raising
the etcd backend quota. The quota increase was applied as a **node-local RKE2 override** — a
file written by hand under `/etc/rancher/rke2/config.yaml.d/` on the affected control-plane
node(s), for example:

```yaml
etcd-arg:
  - "quota-backend-bytes=8589934592"   # 8 GiB
  - "auto-compaction-mode=periodic"
  - "auto-compaction-retention=1h"
```

## Why this belongs in the chart (node-local overrides don't survive node replacement)

The manual override above lives on a single node's local disk. It persists across
`rke2-server` restarts and reboots, but it is **not** part of the cluster's declarative
configuration. Whenever a control-plane node is **replaced or recycled** — autoscaling,
rolling OS/Kubernetes upgrades, machine rollout, or disaster recovery — the new node is
provisioned fresh from the Rancher cluster template and reverts to etcd's **default 2 GB
quota**, silently re-introducing the original failure condition.

Codifying `etcd_arg` in the cluster template moves the setting into Rancher-managed,
declarative config that every current and future control-plane node inherits automatically.
This is the exact preventative action identified in the incident report.

## Changes

- **`templates/cluster.yaml`** — render `etcd-arg` (as a JSON array via `toRawJson`) under
  `machineGlobalConfig` and the control-plane `machineSelectorConfig`, each guarded by an
  `if` so it's only emitted when set.
- **`values.yaml`** — documented the new `etcd_arg` option with a usage example.

Net diff: 2 files, +9 lines.

## Scope decision: why not `workerConfig`?

etcd only runs on nodes with the **etcd role** (co-located with the control plane in the
default topology). Worker-only nodes never run etcd, so an `etcd-arg` under `workerConfig`
would be silently ignored by RKE2 — and could cause a confusing merge conflict on
combined-role nodes. It is therefore intentionally exposed only where it has an effect.

## Testing

- `helm lint charts/cluster-templates` → passes.
- `helm template` with `etcd_arg` set on both configs renders correctly:
  - `machineGlobalConfig.etcd-arg: ["quota-backend-bytes=5368709120","heartbeat-interval=500"]`
  - control-plane `machineSelectorConfig.etcd-arg: ["election-timeout=5000"]`
  - worker `machineSelectorConfig` emits no `etcd-arg`, as intended.

## Example usage

```yaml
cluster:
  config:
    globalConfig:
      etcd_arg:
        - "quota-backend-bytes=8589934592"    # 8 GiB backend quota (default 2 GiB)
        - "auto-compaction-mode=periodic"
        - "auto-compaction-retention=1h"
```
